### PR TITLE
EventLogging: Move retention policy from the Event to the Logger

### DIFF
--- a/src/Lunr/Ticks/InfluxDB1/EventLogging/Event.php
+++ b/src/Lunr/Ticks/InfluxDB1/EventLogging/Event.php
@@ -36,23 +36,15 @@ class Event implements EventInterface
     protected readonly Point $point;
 
     /**
-     * Retention policy for the event.
-     * @var string|null
-     */
-    protected readonly ?string $retentionPolicy;
-
-    /**
      * Constructor.
      *
-     * @param EventLogger $eventLogger     Instance of the EventLogger that created the Event
-     * @param Point       $point           Non-shared InfluxDB1 Point object to hold the event data
-     * @param string|null $retentionPolicy Retention policy for the event
+     * @param EventLogger $eventLogger Instance of the EventLogger that created the Event
+     * @param Point       $point       Non-shared InfluxDB1 Point object to hold the event data
      */
-    public function __construct(EventLogger $eventLogger, Point $point, ?string $retentionPolicy)
+    public function __construct(EventLogger $eventLogger, Point $point)
     {
-        $this->eventLogger     = $eventLogger;
-        $this->point           = $point;
-        $this->retentionPolicy = $retentionPolicy;
+        $this->eventLogger = $eventLogger;
+        $this->point       = $point;
     }
 
     /**
@@ -318,7 +310,7 @@ class Event implements EventInterface
      */
     public function record($precision = Precision::NanoSeconds): void
     {
-        $this->eventLogger->record($this->point, $precision, $this->retentionPolicy);
+        $this->eventLogger->record($this->point, $precision);
     }
 
 }

--- a/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventBaseTest.php
+++ b/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventBaseTest.php
@@ -33,14 +33,6 @@ class EventBaseTest extends EventTestCase
         $this->assertPropertySame('point', $this->point);
     }
 
-    /**
-     * Test that the database is initialized as an empty string.
-     */
-    public function testRetentionPolicyIsPassedCorrectly(): void
-    {
-        $this->assertPropertySame('retentionPolicy', '7d');
-    }
-
 }
 
 ?>

--- a/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventLoggerBaseTest.php
+++ b/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventLoggerBaseTest.php
@@ -46,6 +46,14 @@ class EventLoggerBaseTest extends EventLoggerTestCase
     }
 
     /**
+     * Test that the retention policy is initialized as NULL.
+     */
+    public function testRetentionPolicyIsNull(): void
+    {
+        $this->assertNull($this->getReflectionPropertyValue('retentionPolicy'));
+    }
+
+    /**
      * Test that setDatabase() sets a database name.
      *
      * @covers Lunr\Ticks\InfluxDB1\EventLogging\EventLogger::setDatabase
@@ -55,6 +63,18 @@ class EventLoggerBaseTest extends EventLoggerTestCase
         $this->class->setDatabase('test');
 
         $this->assertPropertySame('database', 'test');
+    }
+
+    /**
+     * Test setRetentionPolicy() overrides the default retention policy.
+     *
+     * @covers Lunr\Ticks\InfluxDB1\EventLogging\EventLogger::setRetentionPolicy
+     */
+    public function testSetRetentionPolicy(): void
+    {
+        $this->class->setRetentionPolicy('1-month');
+
+        $this->assertPropertyEquals('retentionPolicy', '1-month');
     }
 
 }

--- a/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventLoggerNewEventTest.php
+++ b/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventLoggerNewEventTest.php
@@ -22,11 +22,11 @@ class EventLoggerNewEventTest extends EventLoggerTestCase
 {
 
     /**
-     * Test that newEvent() returns an Event instance with default retention policy.
+     * Test that newEvent() returns an Event instance.
      *
      * @covers Lunr\Ticks\InfluxDB1\EventLogging\EventLogger::newEvent
      */
-    public function testNewEventWithDefaultRetentionPolicy(): void
+    public function testNewEvent(): void
     {
         $event = $this->class->newEvent('event');
 
@@ -38,52 +38,6 @@ class EventLoggerNewEventTest extends EventLoggerTestCase
                                         ->getValue($event);
 
         $this->assertSame($this->class, $eventLogger);
-
-        $retentionPolicy = $event_reflection->getProperty('retentionPolicy')
-                                        ->getValue($event);
-
-        $this->assertNull($retentionPolicy);
-
-        $point = $event_reflection->getProperty('point')
-                                  ->getValue($event);
-
-        $this->assertInstanceOf(Point::class, $point);
-
-        $point_reflection = new ReflectionClass(Point::class);
-
-        $measurement = $point_reflection->getProperty('measurement')
-                                        ->getValue($point);
-
-        $this->assertSame('event', $measurement);
-
-        $defaultTags = $point_reflection->getProperty('tags')
-                                        ->getValue($point);
-
-        $this->assertSame($this->defaultTags, $defaultTags);
-    }
-
-    /**
-     * Test that newEvent() returns an Event instance with custom retention policy.
-     *
-     * @covers Lunr\Ticks\InfluxDB1\EventLogging\EventLogger::newEvent
-     */
-    public function testNewEventWithCustomRetentionPolicy(): void
-    {
-        $event = $this->class->newEvent('event', '7d');
-
-        $this->assertInstanceOf(Event::class, $event);
-
-        $event_reflection = new ReflectionClass(Event::class);
-
-        $eventLogger = $event_reflection->getProperty('eventLogger')
-                                        ->getValue($event);
-
-        $this->assertSame($this->class, $eventLogger);
-
-        $retentionPolicy = $event_reflection->getProperty('retentionPolicy')
-                                        ->getValue($event);
-
-        $this->assertSame('7d', $retentionPolicy);
 
         $point = $event_reflection->getProperty('point')
                                   ->getValue($event);

--- a/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventLoggerRecordTest.php
+++ b/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventLoggerRecordTest.php
@@ -24,11 +24,11 @@ class EventLoggerRecordTest extends EventLoggerTestCase
 {
 
     /**
-     * Test that record() logs an event with default retention policy.
+     * Test that record() logs an event.
      *
      * @covers Lunr\Ticks\InfluxDB1\EventLogging\EventLogger::record
      */
-    public function testRecordWithDefaultRetentionPolicy(): void
+    public function testRecordSucceeds(): void
     {
         $this->setReflectionPropertyValue('database', 'test');
 
@@ -58,43 +58,6 @@ class EventLoggerRecordTest extends EventLoggerTestCase
                  ->with([ $point ], InfluxDBV1Precision::PRECISION_NANOSECONDS, NULL);
 
         $this->class->record($point, Precision::NanoSeconds);
-    }
-
-    /**
-     * Test that record() logs an event with custom retention policy.
-     *
-     * @covers Lunr\Ticks\InfluxDB1\EventLogging\EventLogger::record
-     */
-    public function testRecordWithCustomRetentionPolicy(): void
-    {
-        $this->setReflectionPropertyValue('database', 'test');
-
-        $point = $this->getMockBuilder(Point::class)
-                      ->disableOriginalConstructor()
-                      ->getMock();
-
-        $precision = $this->getMockBuilder(InfluxDBV1Precision::class)
-                          ->disableOriginalConstructor()
-                          ->getMock();
-
-        $database = $this->getMockBuilder(Database::class)
-                         ->disableOriginalConstructor()
-                         ->getMock();
-
-        $this->client->expects($this->once())
-                     ->method('getPrecision')
-                     ->willReturn($precision);
-
-        $this->client->expects($this->once())
-                     ->method('selectDB')
-                     ->with('test')
-                     ->willReturn($database);
-
-        $database->expects($this->once())
-                 ->method('writePoints')
-                 ->with([ $point ], InfluxDBV1Precision::PRECISION_SECONDS, '7d');
-
-        $this->class->record($point, Precision::Seconds, '7d');
     }
 
     /**

--- a/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventRecordTest.php
+++ b/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventRecordTest.php
@@ -31,7 +31,6 @@ class EventRecordTest extends EventTestCase
                           ->with(
                               $this->point,
                               Precision::NanoSeconds,
-                              '7d',
                           );
 
         $this->class->record();
@@ -49,7 +48,6 @@ class EventRecordTest extends EventTestCase
                           ->with(
                               $this->point,
                               Precision::Seconds,
-                              '7d',
                           );
 
         $this->class->record(Precision::Seconds);

--- a/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventTestCase.php
+++ b/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventTestCase.php
@@ -56,7 +56,7 @@ abstract class EventTestCase extends LunrBaseTestCase
                                   ->disableOriginalConstructor()
                                   ->getMock();
 
-        $this->class = new Event($this->eventLogger, $this->point, '7d');
+        $this->class = new Event($this->eventLogger, $this->point);
 
         parent::baseSetUp($this->class);
     }

--- a/src/Lunr/Ticks/InfluxDB1/Profiling/Profiler.php
+++ b/src/Lunr/Ticks/InfluxDB1/Profiling/Profiler.php
@@ -23,19 +23,17 @@ class Profiler extends GenericProfiler
     /**
      * Constructor.
      *
-     * @param EventLogger                                     $eventLogger     An observability event logger
-     * @param TracingControllerInterface&TracingInfoInterface $controller      A tracing controller.
-     * @param string                                          $name            Event name
-     * @param string|null                                     $retentionPolicy Retention policy for the event
+     * @param EventLogger                                     $eventLogger An observability event logger
+     * @param TracingControllerInterface&TracingInfoInterface $controller  A tracing controller.
+     * @param string                                          $name        Event name
      */
     public function __construct(
         EventLogger $eventLogger,
         TracingControllerInterface&TracingInfoInterface $controller,
         string $name,
-        ?string $retentionPolicy = NULL,
     )
     {
-        parent::__construct($eventLogger->newEvent($name, $retentionPolicy), $controller);
+        parent::__construct($eventLogger->newEvent($name), $controller);
     }
 
     /**

--- a/src/Lunr/Ticks/InfluxDB1/Profiling/Tests/ProfilerTestCase.php
+++ b/src/Lunr/Ticks/InfluxDB1/Profiling/Tests/ProfilerTestCase.php
@@ -67,7 +67,7 @@ abstract class ProfilerTestCase extends LunrBaseTestCase
 
         $eventlogger->expects($this->once())
                     ->method('newEvent')
-                    ->with('foo', '3m')
+                    ->with('foo')
                     ->willReturn($this->event);
 
         $this->controller = $this->createMockForIntersectionOfInterfaces(
@@ -82,7 +82,7 @@ abstract class ProfilerTestCase extends LunrBaseTestCase
 
         $this->mockFunction('microtime', fn(bool $float) => $float ? $floatval : $stringval);
 
-        $this->class = new Profiler($eventlogger, $this->controller, 'foo', '3m');
+        $this->class = new Profiler($eventlogger, $this->controller, 'foo');
 
         // Unmock here instead of tearDown() because we have another microtime call in the record()
         // method that needs a different mock.


### PR DESCRIPTION
This means that you have to instantiate one EventLogger per retention policy you want to use, rather than specifying it with the event. However, this is more in line with how InfluxDB2 would deal with it, where a different retention policy is essentially a different database.