### PR TITLE
EventLogging: Make database and retentionPolicy readonly properties

### DIFF
--- a/src/Lunr/Ticks/InfluxDB1/EventLogging/EventLogger.php
+++ b/src/Lunr/Ticks/InfluxDB1/EventLogging/EventLogger.php
@@ -38,13 +38,13 @@ class EventLogger implements EventLoggerInterface
      * Name of the database
      * @var string
      */
-    protected string $database;
+    protected readonly string $database;
 
     /**
      * Retention policy to apply
-     * @var string|null
+     * @var string
      */
-    protected ?string $retentionPolicy;
+    protected readonly string $retentionPolicy;
 
     /**
      * Default tags to use for all events.
@@ -61,11 +61,9 @@ class EventLogger implements EventLoggerInterface
      */
     public function __construct(Client $client, LoggerInterface $logger, array $defaultTags = [])
     {
-        $this->client          = $client;
-        $this->logger          = $logger;
-        $this->defaultTags     = $defaultTags;
-        $this->database        = '';
-        $this->retentionPolicy = NULL;
+        $this->client      = $client;
+        $this->logger      = $logger;
+        $this->defaultTags = $defaultTags;
     }
 
     /**
@@ -73,8 +71,7 @@ class EventLogger implements EventLoggerInterface
      */
     public function __destruct()
     {
-        unset($this->database);
-        unset($this->retentionPolicy);
+        // no-op
     }
 
     /**
@@ -143,7 +140,7 @@ class EventLogger implements EventLoggerInterface
 
         try
         {
-            $this->client->selectDB($this->database)->writePoints([ $event ], $influxdbPrecision, $this->retentionPolicy);
+            $this->client->selectDB($this->database)->writePoints([ $event ], $influxdbPrecision, $this->retentionPolicy ?? NULL);
         }
         catch (InfluxDBException $e)
         {

--- a/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventLoggerBaseTest.php
+++ b/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventLoggerBaseTest.php
@@ -38,22 +38,6 @@ class EventLoggerBaseTest extends EventLoggerTestCase
     }
 
     /**
-     * Test that the database is initialized as an empty string.
-     */
-    public function testDatabaseIsEmptyString(): void
-    {
-        $this->assertPropertySame('database', '');
-    }
-
-    /**
-     * Test that the retention policy is initialized as NULL.
-     */
-    public function testRetentionPolicyIsNull(): void
-    {
-        $this->assertNull($this->getReflectionPropertyValue('retentionPolicy'));
-    }
-
-    /**
      * Test that setDatabase() sets a database name.
      *
      * @covers Lunr\Ticks\InfluxDB1\EventLogging\EventLogger::setDatabase

--- a/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventLoggerRecordTest.php
+++ b/src/Lunr/Ticks/InfluxDB1/EventLogging/Tests/EventLoggerRecordTest.php
@@ -31,6 +31,44 @@ class EventLoggerRecordTest extends EventLoggerTestCase
     public function testRecordSucceeds(): void
     {
         $this->setReflectionPropertyValue('database', 'test');
+        $this->setReflectionPropertyValue('retentionPolicy', '1-month');
+
+        $point = $this->getMockBuilder(Point::class)
+                      ->disableOriginalConstructor()
+                      ->getMock();
+
+        $precision = $this->getMockBuilder(InfluxDBV1Precision::class)
+                          ->disableOriginalConstructor()
+                          ->getMock();
+
+        $database = $this->getMockBuilder(Database::class)
+                         ->disableOriginalConstructor()
+                         ->getMock();
+
+        $this->client->expects($this->once())
+                     ->method('getPrecision')
+                     ->willReturn($precision);
+
+        $this->client->expects($this->once())
+                     ->method('selectDB')
+                     ->with('test')
+                     ->willReturn($database);
+
+        $database->expects($this->once())
+                 ->method('writePoints')
+                 ->with([ $point ], InfluxDBV1Precision::PRECISION_NANOSECONDS, '1-month');
+
+        $this->class->record($point, Precision::NanoSeconds);
+    }
+
+    /**
+     * Test that record() logs an event.
+     *
+     * @covers Lunr\Ticks\InfluxDB1\EventLogging\EventLogger::record
+     */
+    public function testRecordSucceedsWithUnsetRetentionPolicy(): void
+    {
+        $this->setReflectionPropertyValue('database', 'test');
 
         $point = $this->getMockBuilder(Point::class)
                       ->disableOriginalConstructor()

--- a/tests/phpstan.neon.dist
+++ b/tests/phpstan.neon.dist
@@ -9,3 +9,8 @@ parameters:
         - phpstan.autoload.inc.php
     excludePaths:
         - ../src/*/Tests/*
+    ignoreErrors:
+        -
+            identifier: property.uninitializedReadonly
+        -
+            identifier: property.readOnlyAssignNotInConstructor


### PR DESCRIPTION
When the EventLogger is used inside `__destruct()` of another class, it can happen that it's own destructor is run before the one of the class it's used in. Then we get errors because of unset properties. This avoids that situation.